### PR TITLE
Feature/allele calling

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Miniconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: taranis_env
           environment-file: environment.yml

--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - bioconda::blast>=2.9
   - bioconda::mash>=2
   - bioconda::prodigal=2.6.3
+  - bioconda::mafft=7.525
   - pip
   - pip :
       -  -r requirements.txt

--- a/taranis/__main__.py
+++ b/taranis/__main__.py
@@ -409,6 +409,15 @@ def reference_alleles(
     help="Threshold value to consider in blast. Values from 0 to 1. default 0.8",
 )
 @click.option(
+    "-p",
+    "--perc-identity",
+    required=False,
+    nargs=1,
+    default=90,
+    type=int,
+    help="Percentage of identity to consider in blast. default 90",
+)
+@click.option(
     "-o",
     "--output",
     required=True,
@@ -455,6 +464,7 @@ def allele_calling(
     annotation: str,
     assemblies: list,
     threshold: float,
+    perc_identity: int,
     output: str,
     force: bool,
     snp: bool,
@@ -500,6 +510,7 @@ def allele_calling(
                 prediction_data,
                 schema_ref_files,
                 threshold,
+                perc_identity,
                 output,
                 inf_allele_obj,
                 snp,
@@ -514,17 +525,19 @@ def allele_calling(
                 print(e)
                 continue
     """
-    import pdb; pdb.set_trace()
-    results = taranis.allele_calling.parallel_execution(
-                assemblies[0],
-                schema,
-                prediction_data,
-                schema_ref_files,
-                threshold,
-                output,
-                inf_allele_obj,
-                snp,
-                alignment,
+    results.append(
+        taranis.allele_calling.parallel_execution(
+            assemblies[0],
+            schema,
+            prediction_data,
+            schema_ref_files,
+            threshold,
+            perc_identity,
+            output,
+            inf_allele_obj,
+            snp,
+            alignment,
+        )
     )
     _ = taranis.allele_calling.collect_data(results, output, snp, alignment)
     finish = time.perf_counter()

--- a/taranis/__main__.py
+++ b/taranis/__main__.py
@@ -492,7 +492,7 @@ def allele_calling(
     cpus: int,
 ):
     _ = taranis.utils.check_additional_programs_installed(
-        [["blastn", "-version"], ["makeblastdb", "-version"]]
+        [["blastn", "-version"], ["makeblastdb", "-version"],["mafft", "--version"]]
     )
     schema_ref_files = taranis.utils.get_files_in_folder(reference, "fasta")
     if len(schema_ref_files) == 0:

--- a/taranis/__main__.py
+++ b/taranis/__main__.py
@@ -492,7 +492,7 @@ def allele_calling(
     cpus: int,
 ):
     _ = taranis.utils.check_additional_programs_installed(
-        [["blastn", "-version"], ["makeblastdb", "-version"],["mafft", "--version"]]
+        [["blastn", "-version"], ["makeblastdb", "-version"], ["mafft", "--version"]]
     )
     schema_ref_files = taranis.utils.get_files_in_folder(reference, "fasta")
     if len(schema_ref_files) == 0:

--- a/taranis/__main__.py
+++ b/taranis/__main__.py
@@ -520,7 +520,7 @@ def allele_calling(
 
     start = time.perf_counter()
     results = []
-    """
+
     with concurrent.futures.ThreadPoolExecutor(max_workers=cpus) as executor:
         futures = [
             executor.submit(
@@ -564,6 +564,7 @@ def allele_calling(
                 increase_sequence,
             )
         )
+    """
     _ = taranis.allele_calling.collect_data(
         results, output, snp, alignment, schema_ref_files
     )

--- a/taranis/__main__.py
+++ b/taranis/__main__.py
@@ -3,7 +3,6 @@ import logging
 import click
 import concurrent.futures
 import glob
-import os
 import rich.console
 import rich.logging
 import rich.traceback

--- a/taranis/__main__.py
+++ b/taranis/__main__.py
@@ -505,7 +505,11 @@ def allele_calling(
         _ = taranis.utils.prompt_user_if_folder_exists(output)
     # Filter fasta files from reference folder
     # ref_alleles = glob.glob(os.path.join(reference, "*.fasta"))
-
+    max_cpus = taranis.utils.cpus_available()
+    if cpus > max_cpus:
+        stderr.print("[red] Number of CPUs bigger than the CPUs available")
+        stderr.print("Running code with ", max_cpus)
+        cpus = max_cpus
     # Read the annotation file
     stderr.print("[green] Reading annotation file")
     log.info("Reading annotation file")
@@ -566,7 +570,7 @@ def allele_calling(
         )
     """
     _ = taranis.allele_calling.collect_data(
-        results, output, snp, alignment, schema_ref_files
+        results, output, snp, alignment, schema_ref_files, cpus
     )
     finish = time.perf_counter()
     print(f"Allele calling finish in {round((finish-start)/60, 2)} minutes")

--- a/taranis/__main__.py
+++ b/taranis/__main__.py
@@ -466,6 +466,12 @@ def allele_calling(
             }
         )
     finish = time.perf_counter()
+    test_file = os.path.join(output, "test_file.csv")
+    with open(test_file, "w") as fo:
+        for result in results:
+            for key, value in result.items():
+                for allele, type in value["allele_type"].items():
+                    fo.write(f"{key},{allele},{type}\n")
     print(f"Allele calling finish in {round((finish-start)/60, 2)} minutes")
     # import pdb; pdb.set_trace()
     # sample_allele_obj.analyze_sample()

--- a/taranis/__main__.py
+++ b/taranis/__main__.py
@@ -539,7 +539,9 @@ def allele_calling(
             alignment,
         )
     )
-    _ = taranis.allele_calling.collect_data(results, output, snp, alignment)
+    _ = taranis.allele_calling.collect_data(
+        results, output, snp, alignment, schema_ref_files
+    )
     finish = time.perf_counter()
     print(f"Allele calling finish in {round((finish-start)/60, 2)} minutes")
     # sample_allele_obj.analyze_sample()

--- a/taranis/__main__.py
+++ b/taranis/__main__.py
@@ -15,7 +15,6 @@ import taranis.reference_alleles
 import taranis.allele_calling
 
 import taranis.inferred_alleles
-from pathlib import Path
 
 log = logging.getLogger()
 

--- a/taranis/__main__.py
+++ b/taranis/__main__.py
@@ -217,6 +217,7 @@ def analyze_schema(
     usegenus: str,
     cpus: int,
 ):
+    _= taranis.utils.check_additional_programs_installed(["prokka"])
     schema_files = taranis.utils.get_files_in_folder(inputdir, "fasta")
 
     results = []
@@ -333,6 +334,7 @@ def reference_alleles(
     cpus: int,
     force: bool,
 ):
+    _= taranis.utils.check_additional_programs_installed(["mash", "makeblastdb", "blastn"])
     start = time.perf_counter()
     max_cpus = taranis.utils.cpus_available()
     if cpus > max_cpus:
@@ -425,6 +427,7 @@ def allele_calling(
     output: str,
     force: bool,
 ):
+    _= taranis.utils.check_additional_programs_installed(["blastn", "makeblastdb"])
     schema_ref_files = taranis.utils.get_files_in_folder(reference, "fasta")
     if len(schema_ref_files) == 0:
         log.error("Referenc allele folder %s does not have any fasta file", schema)

--- a/taranis/__main__.py
+++ b/taranis/__main__.py
@@ -15,6 +15,7 @@ import taranis.analyze_schema
 import taranis.reference_alleles
 import taranis.allele_calling
 
+import taranis.inferred_alleles
 from pathlib import Path
 
 log = logging.getLogger()
@@ -445,7 +446,11 @@ def allele_calling(
     pred_sample.prediction()
     """
     map_pred = [["gene", 7], ["product", 8], ["allele_quality", 9]]
-    prediction_data = taranis.utils.read_compressed_file(annotation, separator=",", index_key=1, mapping=map_pred)
+    prediction_data = taranis.utils.read_compressed_file(
+        annotation, separator=",", index_key=1, mapping=map_pred
+    )
+    # Create the instanace for inference alleles
+    inf_allele_obj = taranis.inferred_alleles.InferredAllele()
     """Analyze the sample file against schema to identify outbreakers
     """
     start = time.perf_counter()
@@ -455,7 +460,12 @@ def allele_calling(
         results.append(
             {
                 assembly_name: taranis.allele_calling.parallel_execution(
-                    assembly_file, schema, prediction_data, schema_ref_files, output
+                    assembly_file,
+                    schema,
+                    prediction_data,
+                    schema_ref_files,
+                    output,
+                    inf_allele_obj,
                 )
             }
         )

--- a/taranis/__main__.py
+++ b/taranis/__main__.py
@@ -454,6 +454,7 @@ def allele_calling(
 
     """Analyze the sample file against schema to identify outbreakers
     """
+    start = time.perf_counter()
     results = []
     for assembly_file in assemblies:
         assembly_name = Path(assembly_file).stem
@@ -464,5 +465,7 @@ def allele_calling(
                 )
             }
         )
-
+    finish = time.perf_counter()
+    print(f"Allele calling finish in {round((finish-start)/60, 2)} minutes")
+    # import pdb; pdb.set_trace()
     # sample_allele_obj.analyze_sample()

--- a/taranis/__main__.py
+++ b/taranis/__main__.py
@@ -217,7 +217,7 @@ def analyze_schema(
     usegenus: str,
     cpus: int,
 ):
-    _= taranis.utils.check_additional_programs_installed(["prokka"])
+    _ = taranis.utils.check_additional_programs_installed(["prokka"])
     schema_files = taranis.utils.get_files_in_folder(inputdir, "fasta")
 
     results = []
@@ -334,7 +334,9 @@ def reference_alleles(
     cpus: int,
     force: bool,
 ):
-    _= taranis.utils.check_additional_programs_installed(["mash", "makeblastdb", "blastn"])
+    _ = taranis.utils.check_additional_programs_installed(
+        ["mash", "makeblastdb", "blastn"]
+    )
     start = time.perf_counter()
     max_cpus = taranis.utils.cpus_available()
     if cpus > max_cpus:
@@ -427,7 +429,7 @@ def allele_calling(
     output: str,
     force: bool,
 ):
-    _= taranis.utils.check_additional_programs_installed(["blastn", "makeblastdb"])
+    _ = taranis.utils.check_additional_programs_installed(["blastn", "makeblastdb"])
     schema_ref_files = taranis.utils.get_files_in_folder(reference, "fasta")
     if len(schema_ref_files) == 0:
         log.error("Referenc allele folder %s does not have any fasta file", schema)
@@ -474,5 +476,4 @@ def allele_calling(
     _ = taranis.allele_calling.collect_data(results, output)
     finish = time.perf_counter()
     print(f"Allele calling finish in {round((finish-start)/60, 2)} minutes")
-    # import pdb; pdb.set_trace()
     # sample_allele_obj.analyze_sample()

--- a/taranis/__main__.py
+++ b/taranis/__main__.py
@@ -217,7 +217,7 @@ def analyze_schema(
     usegenus: str,
     cpus: int,
 ):
-    _ = taranis.utils.check_additional_programs_installed(["prokka"])
+    _ = taranis.utils.check_additional_programs_installed([["prokka", "--version"]])
     schema_files = taranis.utils.get_files_in_folder(inputdir, "fasta")
 
     results = []
@@ -335,7 +335,7 @@ def reference_alleles(
     force: bool,
 ):
     _ = taranis.utils.check_additional_programs_installed(
-        ["mash", "makeblastdb", "blastn"]
+        [["mash", "--version"], ["makeblastdb", "-version"], ["blastn", "-version"]]
     )
     start = time.perf_counter()
     max_cpus = taranis.utils.cpus_available()
@@ -429,7 +429,9 @@ def allele_calling(
     output: str,
     force: bool,
 ):
-    _ = taranis.utils.check_additional_programs_installed(["blastn", "makeblastdb"])
+    _ = taranis.utils.check_additional_programs_installed(
+        [["blastn", "-version"], ["makeblastdb", "-version"]]
+    )
     schema_ref_files = taranis.utils.get_files_in_folder(reference, "fasta")
     if len(schema_ref_files) == 0:
         log.error("Referenc allele folder %s does not have any fasta file", schema)

--- a/taranis/__main__.py
+++ b/taranis/__main__.py
@@ -389,6 +389,14 @@ def reference_alleles(
     help="Directory where the schema reference allele files are located. ",
 )
 @click.option(
+    "-a",
+    "--annotation",
+    required=True,
+    multiple=False,
+    type=click.Path(exists=True),
+    help="Annotation file. ",
+)
+@click.option(
     "-o",
     "--output",
     required=True,
@@ -412,6 +420,7 @@ def reference_alleles(
 def allele_calling(
     schema: str,
     reference: str,
+    annotation: str,
     assemblies: list,
     output: str,
     force: bool,
@@ -435,7 +444,8 @@ def allele_calling(
     pred_sample.training()
     pred_sample.prediction()
     """
-
+    map_pred = [["gene", 7], ["product", 8], ["allele_quality", 9]]
+    prediction_data = taranis.utils.read_compressed_file(annotation, separator=",", index_key=1, mapping=map_pred)
     """Analyze the sample file against schema to identify outbreakers
     """
     start = time.perf_counter()
@@ -445,7 +455,7 @@ def allele_calling(
         results.append(
             {
                 assembly_name: taranis.allele_calling.parallel_execution(
-                    assembly_file, schema, schema_ref_files, output
+                    assembly_file, schema, prediction_data, schema_ref_files, output
                 )
             }
         )

--- a/taranis/__main__.py
+++ b/taranis/__main__.py
@@ -451,6 +451,24 @@ def reference_alleles(
     help="Create alignment files",
 )
 @click.option(
+    "-q",
+    "--proteine-threshold",
+    required=False,
+    nargs=1,
+    default=80,
+    type=int,
+    help="Threshold of protein coverage to consider as TPR. default 90",
+)
+@click.option(
+    "-i",
+    "--increase-sequence",
+    required=False,
+    nargs=1,
+    default=20,
+    type=int,
+    help="Increase the number of triplet sequences to find the stop codon. default 20",
+)
+@click.option(
     "--cpus",
     required=False,
     multiple=False,
@@ -469,6 +487,8 @@ def allele_calling(
     force: bool,
     snp: bool,
     alignment: bool,
+    proteine_threshold: int,
+    increase_sequence: int,
     cpus: int,
 ):
     _ = taranis.utils.check_additional_programs_installed(
@@ -515,6 +535,8 @@ def allele_calling(
                 inf_allele_obj,
                 snp,
                 alignment,
+                proteine_threshold,
+                increase_sequence,
             )
             for assembly_file in assemblies
         ]
@@ -525,23 +547,27 @@ def allele_calling(
                 print(e)
                 continue
     """
-    results.append(
-        taranis.allele_calling.parallel_execution(
-            assemblies[0],
-            schema,
-            prediction_data,
-            schema_ref_files,
-            threshold,
-            perc_identity,
-            output,
-            inf_allele_obj,
-            snp,
-            alignment,
+    for assembly_file in assemblies:
+        results.append(
+            taranis.allele_calling.parallel_execution(
+                assembly_file,
+                schema,
+                prediction_data,
+                schema_ref_files,
+                threshold,
+                perc_identity,
+                output,
+                inf_allele_obj,
+                snp,
+                alignment,
+                proteine_threshold,
+                increase_sequence,
+            )
         )
-    )
     _ = taranis.allele_calling.collect_data(
         results, output, snp, alignment, schema_ref_files
     )
     finish = time.perf_counter()
     print(f"Allele calling finish in {round((finish-start)/60, 2)} minutes")
+    log.info("Allele calling finish in %s minutes", round((finish-start)/60, 2))
     # sample_allele_obj.analyze_sample()

--- a/taranis/__main__.py
+++ b/taranis/__main__.py
@@ -569,5 +569,5 @@ def allele_calling(
     )
     finish = time.perf_counter()
     print(f"Allele calling finish in {round((finish-start)/60, 2)} minutes")
-    log.info("Allele calling finish in %s minutes", round((finish-start)/60, 2))
+    log.info("Allele calling finish in %s minutes", round((finish - start) / 60, 2))
     # sample_allele_obj.analyze_sample()

--- a/taranis/__main__.py
+++ b/taranis/__main__.py
@@ -424,13 +424,13 @@ def reference_alleles(
     "--snp/--no-snp",
     required=False,
     default=False,
-    help="Create SNP file for alleles that are infered INF",
+    help="Create SNP file for alleles in assembly in relation with reference allele",
 )
 @click.option(
     "--alignment/--no-alignment",
     required=False,
     default=False,
-    help="Create aligment file for Overwrite the output folder if it exists",
+    help="Create alignment files",
 )
 @click.option(
     "--cpus",
@@ -475,7 +475,7 @@ def allele_calling(
     )
     # Create the instanace for inference alleles
     inf_allele_obj = taranis.inferred_alleles.InferredAllele()
-    """Analyze the sample file against schema to identify outbreakers
+    """Analyze the sample file against schema to identify alleles
     """
 
     start = time.perf_counter()

--- a/taranis/__main__.py
+++ b/taranis/__main__.py
@@ -400,6 +400,15 @@ def reference_alleles(
     help="Annotation file. ",
 )
 @click.option(
+    "-t",
+    "--threshold",
+    required=False,
+    nargs=1,
+    default=0.8,
+    type=float,
+    help="Threshold value to consider in blast. Values from 0 to 1. default 0.8",
+)
+@click.option(
     "-o",
     "--output",
     required=True,
@@ -445,6 +454,7 @@ def allele_calling(
     reference: str,
     annotation: str,
     assemblies: list,
+    threshold: float,
     output: str,
     force: bool,
     snp: bool,
@@ -480,6 +490,7 @@ def allele_calling(
 
     start = time.perf_counter()
     results = []
+    """
     with concurrent.futures.ThreadPoolExecutor(max_workers=cpus) as executor:
         futures = [
             executor.submit(
@@ -488,6 +499,7 @@ def allele_calling(
                 schema,
                 prediction_data,
                 schema_ref_files,
+                threshold,
                 output,
                 inf_allele_obj,
                 snp,
@@ -501,7 +513,19 @@ def allele_calling(
             except Exception as e:
                 print(e)
                 continue
-
+    """
+    import pdb; pdb.set_trace()
+    results = taranis.allele_calling.parallel_execution(
+                assemblies[0],
+                schema,
+                prediction_data,
+                schema_ref_files,
+                threshold,
+                output,
+                inf_allele_obj,
+                snp,
+                alignment,
+    )
     _ = taranis.allele_calling.collect_data(results, output, snp, alignment)
     finish = time.perf_counter()
     print(f"Allele calling finish in {round((finish-start)/60, 2)} minutes")

--- a/taranis/allele_calling.py
+++ b/taranis/allele_calling.py
@@ -166,3 +166,45 @@ def parallel_execution(
 ):
     allele_obj = AlleleCalling(sample_file, schema, reference_alleles, out_folder)
     return allele_obj.search_match_allele()
+
+
+def collect_data(results: list, output: str) -> None:
+    summary_result_file = os.path.join(output, "allele_calling_summary.csv")
+    sample_allele_match_file = os.path.join(output, "allele_calling_match.csv")
+    a_types = ["NIPHEM", "EXC", "PLOT", "ASM", "ALM", "INF", "LNF"]
+    summary_result = {}
+    sample_allele_match = {}
+    # get allele list
+    first_sample = list(results[0].keys())[0]
+    allele_list = sorted(results[0][first_sample]["allele_type"].keys())
+    for result in results:
+        for sample, values in result.items():
+            sum_allele_type = OrderedDict() # used for summary file
+            allele_match = {}
+            for a_type in a_types:
+                sum_allele_type[a_type] = 0
+            for allele, type in values["allele_type"].items():
+                # increase allele type count
+                sum_allele_type[type] += 1
+                # add allele name match to sample
+                allele_match[allele] = type + "_" + values["allele_match"][allele]
+            summary_result[sample] = sum_allele_type
+            sample_allele_match[sample] = allele_match
+
+    with open(summary_result_file, "w") as fo:
+        fo.write("Sample," + ",".join(a_types) + "\n")
+        for sample, counts in summary_result.items():
+            fo.write(f"{sample},")
+            for _ , count in counts.items():
+                fo.write(f"{count},")
+            fo.write("\n")
+    with open(sample_allele_match_file, "w") as fo:
+        fo.write("Sample," + ",".join(allele_list) + "\n")
+        for sample, allele_cod in sample_allele_match.items():
+            fo.write(f"{sample},")
+            for allele  in allele_list:
+                fo.write(f"{allele_cod[allele]},")
+            fo.write("\n")
+
+
+

--- a/taranis/allele_calling.py
+++ b/taranis/allele_calling.py
@@ -547,10 +547,10 @@ class AlleleCalling:
                 )
             if self.aligment_request and result["allele_type"][allele_name] != "LNF":
                 # run alignment analysis
-                result["alignment_data"][
-                    allele_name
-                ] = taranis.utils.get_alignment_data(
-                    ref_allele_seq, allele_seq, ref_allele_name
+                result["alignment_data"][allele_name] = (
+                    taranis.utils.get_alignment_data(
+                        ref_allele_seq, allele_seq, ref_allele_name
+                    )
                 )
         # delete blast folder
         _ = taranis.utils.delete_folder(self.blast_dir)

--- a/taranis/allele_calling.py
+++ b/taranis/allele_calling.py
@@ -11,8 +11,6 @@ from collections import OrderedDict
 from pathlib import Path
 from Bio import SeqIO
 
-import pdb
-
 log = logging.getLogger(__name__)
 stderr = rich.console.Console(
     stderr=True,
@@ -253,7 +251,7 @@ def collect_data(results: list, output: str) -> None:
     ]
     summary_result = {}
     sample_allele_match = {}
-    sample_allele_detail = {}
+
     # get allele list
     first_sample = list(results[0].keys())[0]
     allele_list = sorted(results[0][first_sample]["allele_type"].keys())

--- a/taranis/allele_calling.py
+++ b/taranis/allele_calling.py
@@ -3,7 +3,6 @@ import logging
 import os
 import rich.console
 
-
 import taranis.utils
 import taranis.blast
 
@@ -47,15 +46,17 @@ class AlleleCalling:
         self, blast_result: list, allele_file: str, allele_name: str
     ) -> list:
         def get_blast_details(blast_result: list, allele_name: str) -> list:
+            match_allele_name = blast_result[0]
             try:
-                gene_annotation = self.prediction_data[allele_name]["gene"]
-                product_annotation = self.prediction_data[allele_name]["product"]
-                allele_quality = self.prediction_data[allele_name]["quality"]
+                gene_annotation = self.prediction_data[match_allele_name]["gene"]
+                product_annotation = self.prediction_data[match_allele_name]["product"]
+                allele_quality = self.prediction_data[match_allele_name][
+                    "allele_quality"
+                ].strip()
             except KeyError:
                 gene_annotation = "Not found"
                 product_annotation = "Not found"
                 allele_quality = "Not found"
-
             if int(blast_result[10]) > int(blast_result[9]):
                 direction = "+"
             else:

--- a/taranis/allele_calling.py
+++ b/taranis/allele_calling.py
@@ -127,7 +127,7 @@ class AlleleCalling:
         for b_result in blast_result:
             column_blast_res = b_result.split("\t")
             query_length = int(column_blast_res[4]) / int(column_blast_res[3])
-            if query_length >= 0.8:
+            if query_length >= self.threshold:
                 valid_blast_result.append(b_result)
                 if query_length == 1:
                     match_full_length += 1

--- a/taranis/allele_calling.py
+++ b/taranis/allele_calling.py
@@ -391,7 +391,7 @@ def collect_data(
         for sample, allele_cod in sample_allele_match.items():
             fo.write(f"{sample},")
             for allele in allele_list:
-                fo.write(f"{allele_cod[allele]},")
+                fo.write(f"{allele_cod[allele]}")
             fo.write("\n")
 
     with open(sample_allele_detail_file, "w") as fo:

--- a/taranis/allele_calling.py
+++ b/taranis/allele_calling.py
@@ -28,6 +28,7 @@ class AlleleCalling:
         annotation: dict,
         reference_alleles: list,
         threshold: float,
+        perc_identity: int,
         out_folder: str,
         inf_alle_obj: object,
         snp_request: bool = False,
@@ -51,6 +52,7 @@ class AlleleCalling:
         self.schema = schema
         self.ref_alleles = reference_alleles
         self.threshold = threshold
+        self.perc_identity = perc_identity
         self.out_folder = out_folder
         self.s_name = Path(sample_file).stem
         self.blast_dir = os.path.join(out_folder, "blastdb")
@@ -302,7 +304,7 @@ class AlleleCalling:
                 query_file.seek(0)
                 blast_result = self.blast_obj.run_blast(
                     query_file.read(),
-                    perc_identity=90,
+                    perc_identity=self.perc_identity,
                     num_threads=1,
                     query_type="stdin",
                 )
@@ -313,7 +315,6 @@ class AlleleCalling:
             query_file.close()
             if match_found:
                 allele_file = os.path.join(self.schema, os.path.basename(ref_allele))
-                # blast_result = self.blast_obj.run_blast(q_file,perc_identity=100)
                 allele_name = Path(allele_file).stem
                 (
                     result["allele_type"][allele_name],
@@ -347,6 +348,7 @@ def parallel_execution(
     prediction_data: dict,
     reference_alleles: list,
     threshold: float,
+    perc_identity: int,
     out_folder: str,
     inf_alle_obj: object,
     snp_request: bool = False,
@@ -358,6 +360,7 @@ def parallel_execution(
         prediction_data,
         reference_alleles,
         threshold,
+        perc_identity,
         out_folder,
         inf_alle_obj,
         snp_request,

--- a/taranis/allele_calling.py
+++ b/taranis/allele_calling.py
@@ -65,7 +65,6 @@ class AlleleCalling:
             allele_details = get_blast_details(column_blast_res, allele_name)
             return ["NIPHEM", allele_name, allele_details]
 
-
         elif len(blast_result) == 1:
             column_blast_res = blast_result[0].split("\t")
             column_blast_res[13] = column_blast_res[13].replace("-", "")
@@ -113,7 +112,14 @@ class AlleleCalling:
         count = 0
         for ref_allele in self.ref_alleles:
             count += 1
-            print(" Processing allele ", ref_allele, " ", count, " of ", len(self.ref_alleles))
+            print(
+                " Processing allele ",
+                ref_allele,
+                " ",
+                count,
+                " of ",
+                len(self.ref_alleles),
+            )
             # schema_alleles = os.path.join(self.schema, ref_allele)
             # parallel in all CPUs in cluster node
             alleles = OrderedDict()
@@ -131,7 +137,10 @@ class AlleleCalling:
                 query_file.write(">" + r_id + "\n" + r_seq)
                 query_file.seek(0)
                 blast_result = self.blast_obj.run_blast(
-                    query_file.read(), perc_identity=90, num_threads=4, query_type="stdin"
+                    query_file.read(),
+                    perc_identity=90,
+                    num_threads=4,
+                    query_type="stdin",
                 )
                 if len(blast_result) > 0:
                     match_found = True
@@ -179,7 +188,7 @@ def collect_data(results: list, output: str) -> None:
     allele_list = sorted(results[0][first_sample]["allele_type"].keys())
     for result in results:
         for sample, values in result.items():
-            sum_allele_type = OrderedDict() # used for summary file
+            sum_allele_type = OrderedDict()  # used for summary file
             allele_match = {}
             for a_type in a_types:
                 sum_allele_type[a_type] = 0
@@ -195,16 +204,13 @@ def collect_data(results: list, output: str) -> None:
         fo.write("Sample," + ",".join(a_types) + "\n")
         for sample, counts in summary_result.items():
             fo.write(f"{sample},")
-            for _ , count in counts.items():
+            for _, count in counts.items():
                 fo.write(f"{count},")
             fo.write("\n")
     with open(sample_allele_match_file, "w") as fo:
         fo.write("Sample," + ",".join(allele_list) + "\n")
         for sample, allele_cod in sample_allele_match.items():
             fo.write(f"{sample},")
-            for allele  in allele_list:
+            for allele in allele_list:
                 fo.write(f"{allele_cod[allele]},")
             fo.write("\n")
-
-
-

--- a/taranis/allele_calling.py
+++ b/taranis/allele_calling.py
@@ -103,7 +103,8 @@ class AlleleCalling:
                 # allele is labled as INF
                 return ["INF", allele_name, allele_details]
         else:
-            pdb.set_trace()
+            print("ERROR: No blast result found")
+            return ["LNF", "allele_name", "LNF"]
 
     def search_match_allele(self):
         # Create  blast db with sample file
@@ -123,7 +124,7 @@ class AlleleCalling:
             count_2 = 0
             for r_id, r_seq in alleles.items():
                 count_2 += 1
-                pdb.set_trace()
+
                 print("Running blast for ", count_2, " of ", len(alleles))
                 # create file in memory to increase speed
                 query_file = io.StringIO()
@@ -149,7 +150,7 @@ class AlleleCalling:
                     ) = self.assign_allele_type(blast_result, allele_file, allele_name)
                 except Exception as e:
                     stderr.print(f"Error: {e}")
-                    pdb.set_trace()
+
             else:
                 # Sample does not have a reference allele to be matched
                 # Keep LNF info

--- a/taranis/allele_calling.py
+++ b/taranis/allele_calling.py
@@ -336,9 +336,9 @@ class AlleleCalling:
             if self.aligment_request and result["allele_type"][allele_name] != "LNF":
                 # run alignment analysis
                 allele_seq = result["allele_details"][allele_name][14]
-                result["alignment_data"][
-                    allele_name
-                ] = taranis.utils.get_alignment_data(allele_seq, alleles)
+                result["alignment_data"][allele_name] = (
+                    taranis.utils.get_alignment_data(allele_seq, alleles)
+                )
         return result
 
 

--- a/taranis/allele_calling.py
+++ b/taranis/allele_calling.py
@@ -12,8 +12,6 @@ from Bio.Seq import Seq
 from Bio import SeqIO
 from io import StringIO
 
-import pdb
-
 log = logging.getLogger(__name__)
 stderr = rich.console.Console(
     stderr=True,
@@ -316,7 +314,6 @@ class AlleleCalling:
                 prot_conv_result["protein"] if "protein" in prot_conv_result else "-"
             )
             # remove if additional sequenced are added at the end of the stop codon
-            # pdb.set_trace()
             if "additional bases added after stop codon" in prot_error_result:
                 new_seq_len = len(match_sequence) // 3 * 3
                 match_sequence = match_sequence[:new_seq_len]
@@ -489,7 +486,7 @@ class AlleleCalling:
 
             alleles = taranis.utils.read_fasta_file(ref_allele, convert_to_dict=True)
             match_found = False
-            """ 
+            """
             with open(ref_allele, "r") as fh:
                 for record in SeqIO.parse(fh, "fasta"):
                     alleles[record.id] = str(record.seq)
@@ -534,15 +531,17 @@ class AlleleCalling:
             # prepare the data for snp and alignment analysis
             try:
                 ref_allele_seq = result["allele_details"][allele_name][15]
-            except:
-                pdb.set_trace()
+            except KeyError as e:
+                log.error("Error in allele details")
+                log.error(e)
+                stderr.print(f"Error in allele details{e}")
+                continue
             allele_seq = result["allele_details"][allele_name][14]
             ref_allele_name = result["allele_details"][allele_name][3]
 
             if self.snp_request and result["allele_type"][allele_name] != "LNF":
                 # run snp analysis
-                print(allele_name)
-                # pdb.set_trace()
+                # print(allele_name)
                 result["snp_data"][allele_name] = taranis.utils.get_snp_information(
                     ref_allele_seq, allele_seq, ref_allele_name
                 )

--- a/taranis/allele_calling.py
+++ b/taranis/allele_calling.py
@@ -5,7 +5,7 @@ import rich.console
 
 import taranis.utils
 import taranis.blast
-import pdb
+
 from collections import OrderedDict
 from pathlib import Path
 from Bio import SeqIO
@@ -294,6 +294,35 @@ def parallel_execution(
 def collect_data(
     results: list, output: str, snp_request: bool, aligment_request: bool
 ) -> None:
+    def stats_graphics(stats_folder: str, summary_result: dict) -> None:
+        stderr.print("Creating graphics")
+        log.info("Creating graphics")
+        allele_types = ["NIPHEM", "NIPH", "EXC", "PLOT", "ASM", "ALM", "INF", "LNF"]
+        # inizialize classification data
+        classif_data = {}
+        for allele_type in allele_types:
+            classif_data[allele_type] = []
+        graphic_folder = os.path.join(stats_folder, "graphics")
+
+        _ = taranis.utils.create_new_folder(graphic_folder)
+        s_list = []
+        # collecting data to create graphics
+        for sample, classif_counts in summary_result.items():
+            s_list.append(sample)  # create list of samples
+            for classif, count in classif_counts.items():
+                classif_data[classif].append(int(count))
+        # create graphics
+        for allele_type, counts in classif_data.items():
+            _ = taranis.utils.create_graphic(
+                graphic_folder,
+                str(allele_type + "_graphic.png"),
+                "bar",
+                s_list,
+                counts,
+                ["Samples", "number"],
+                str("Number of " + allele_type + " in samples"),
+            )
+
     summary_result_file = os.path.join(output, "allele_calling_summary.csv")
     sample_allele_match_file = os.path.join(output, "allele_calling_match.csv")
     sample_allele_detail_file = os.path.join(output, "matching_contig.csv")
@@ -315,6 +344,7 @@ def collect_data(
         "allele quality",
         "sequence",
     ]
+
     summary_result = {}
     sample_allele_match = {}
 
@@ -384,3 +414,5 @@ def collect_data(
                                 + ",".join(snp_info)
                                 + "\n"
                             )
+    # Create graphics
+    stats_graphics(output, summary_result)

--- a/taranis/allele_calling.py
+++ b/taranis/allele_calling.py
@@ -585,10 +585,10 @@ class AlleleCalling:
                 )
             if self.aligment_request and result["allele_type"][allele_name] != "LNF":
                 # run alignment analysis
-                result["alignment_data"][
-                    allele_name
-                ] = taranis.utils.get_alignment_data(
-                    ref_allele_seq, allele_seq, ref_allele_name
+                result["alignment_data"][allele_name] = (
+                    taranis.utils.get_alignment_data(
+                        ref_allele_seq, allele_seq, ref_allele_name
+                    )
                 )
         # delete blast folder
         _ = taranis.utils.delete_folder(os.path.join(self.blast_dir, self.s_name))

--- a/taranis/allele_calling.py
+++ b/taranis/allele_calling.py
@@ -584,10 +584,10 @@ class AlleleCalling:
                 )
             if self.aligment_request and result["allele_type"][allele_name] != "LNF":
                 # run alignment analysis
-                result["alignment_data"][
-                    allele_name
-                ] = taranis.utils.get_alignment_data(
-                    ref_allele_seq, allele_seq, ref_allele_name
+                result["alignment_data"][allele_name] = (
+                    taranis.utils.get_alignment_data(
+                        ref_allele_seq, allele_seq, ref_allele_name
+                    )
                 )
         # delete blast folder
         _ = taranis.utils.delete_folder(os.path.join(self.blast_dir, self.s_name))

--- a/taranis/allele_calling.py
+++ b/taranis/allele_calling.py
@@ -269,9 +269,9 @@ class AlleleCalling:
             if self.aligment_request and result["allele_type"][allele_name] == "INF":
                 # run alignment analysis
                 allele_seq = result["allele_details"][allele_name][14]
-                result["alignment_data"][
-                    allele_name
-                ] = taranis.utils.get_alignment_data(allele_seq, alleles)
+                result["alignment_data"][allele_name] = (
+                    taranis.utils.get_alignment_data(allele_seq, alleles)
+                )
         return result
 
 

--- a/taranis/analyze_schema.py
+++ b/taranis/analyze_schema.py
@@ -86,9 +86,11 @@ class AnalyzeSchema:
         with open(self.schema_allele) as fh:
             for record in SeqIO.parse(fh, "fasta"):
                 try:
-                    prokka_ann = prokka_annotation[record.id]
+                    prokka_ann = prokka_annotation[record.id]["gene"]
+                    product_annotation = prokka_annotation[record.id]["product"]
                 except Exception:
                     prokka_ann = "Not found in prokka"
+                    product_annotation = "Not found"
                 a_quality[record.id] = {
                     "allele_name": self.allele_name,
                     "quality": "Good quality",
@@ -97,7 +99,7 @@ class AnalyzeSchema:
                     "start_codon_alt": "standard",
                     "protein_seq": "",
                     "cds_coding": prokka_ann,
-                }
+                    "product_annotation": product_annotation,                }
                 allele_seq[record.id] = str(record.seq)
                 a_quality[record.id]["length"] = str(len(str(record.seq)))
                 a_quality[record.id]["dna_seq"] = str(record.seq)

--- a/taranis/analyze_schema.py
+++ b/taranis/analyze_schema.py
@@ -372,6 +372,7 @@ def collect_statistics(data, out_folder, output_allele_annot):
             "nucleotide sequence length",
             "star codon",
             "CDS coding",
+            "product annotation",
             "allele quality",
             "bad quality reason",
         ]
@@ -382,6 +383,7 @@ def collect_statistics(data, out_folder, output_allele_annot):
             "length",
             "start_codon_alt",
             "cds_coding",
+            "product_annotation",
             "quality",
             "reason",
         ]

--- a/taranis/analyze_schema.py
+++ b/taranis/analyze_schema.py
@@ -99,7 +99,8 @@ class AnalyzeSchema:
                     "start_codon_alt": "standard",
                     "protein_seq": "",
                     "cds_coding": prokka_ann,
-                    "product_annotation": product_annotation,                }
+                    "product_annotation": product_annotation,
+               }
                 allele_seq[record.id] = str(record.seq)
                 a_quality[record.id]["length"] = str(len(str(record.seq)))
                 a_quality[record.id]["dna_seq"] = str(record.seq)

--- a/taranis/analyze_schema.py
+++ b/taranis/analyze_schema.py
@@ -100,7 +100,7 @@ class AnalyzeSchema:
                     "protein_seq": "",
                     "cds_coding": prokka_ann,
                     "product_annotation": product_annotation,
-               }
+                }
                 allele_seq[record.id] = str(record.seq)
                 a_quality[record.id]["length"] = str(len(str(record.seq)))
                 a_quality[record.id]["dna_seq"] = str(record.seq)

--- a/taranis/blast.py
+++ b/taranis/blast.py
@@ -96,7 +96,7 @@ class Blast:
         if query_type == "stdin":
             stdin_query = query
             query = "-"
-        blast_parameters = '"6 , qseqid , sseqid , pident ,  qlen , length , mismatch , gapopen , evalue , bitscore , sstart , send , qstart , qend , sseq , slen"'
+        blast_parameters = '"6 , qseqid , sseqid , pident ,  qlen , length , mismatch , gapopen , evalue , bitscore , sstart , send , qstart , qend , sseq , qseq , slen"'
         cline = NcbiblastnCommandline(
             task="blastn",
             db=self.out_blast_dir,

--- a/taranis/distance.py
+++ b/taranis/distance.py
@@ -64,10 +64,10 @@ class DistanceMatrix:
             )
             stderr.print(f"{e}")
             sys.exit(1)
-
-        # Close the file handles
-        mash_distance_result.stdout.close()
-        mash_distance_result.stderr.close()
+        finally:
+            # Close the file handles
+            mash_distance_result.stdout.close()
+            mash_distance_result.stderr.close()
 
         out_data = out.decode("UTF-8").split("\n")
         allele_names = [item.split("\t")[0] for item in out_data[1:-1]]

--- a/taranis/inferred_alleles.py
+++ b/taranis/inferred_alleles.py
@@ -1,3 +1,6 @@
+import pdb
+
+
 class InferredAllele:
     def __init__(self):
         self.inferred_seq = {}
@@ -23,6 +26,8 @@ class InferredAllele:
             sequence (str): sequence to infer the allele
             allele (str): inferred allele
         """
-        inf_value = self.last_allele_index.get(allele, 0) + 1
-        self.inferred_seq[sequence] = inf_value
+        if allele not in self.last_allele_index:
+            self.last_allele_index[allele] = 0
+        self.last_allele_index[allele] += 1
+        self.inferred_seq[sequence] = self.last_allele_index[allele]
         return self.inferred_seq[sequence]

--- a/taranis/inferred_alleles.py
+++ b/taranis/inferred_alleles.py
@@ -1,6 +1,3 @@
-import pdb
-
-
 class InferredAllele:
     def __init__(self):
         self.inferred_seq = {}

--- a/taranis/inferred_alleles.py
+++ b/taranis/inferred_alleles.py
@@ -1,0 +1,31 @@
+import pdb
+
+
+class InferredAllele:
+    def __init__(self):
+        self.inferred_seq = {}
+        self.last_allele_index = {}
+
+    def get_inferred_allele(self, sequence: str, allele: str) -> str:
+        """Infer allele from the sequence
+
+        Args:
+            sequence (str): sequence to infer the allele
+
+        Returns:
+            str: inferred allele
+        """
+        if sequence not in self.inferred_seq:
+            return self.set_inferred_allele(sequence, allele)
+        return self.inferred_seq[sequence]
+
+    def set_inferred_allele(self, sequence: str, allele: str) -> None:
+        """Set the inferred allele for the sequence
+
+        Args:
+            sequence (str): sequence to infer the allele
+            allele (str): inferred allele
+        """
+        inf_value = self.last_allele_index.get(allele, 0) + 1
+        self.inferred_seq[sequence] = inf_value
+        return self.inferred_seq[sequence]

--- a/taranis/inferred_alleles.py
+++ b/taranis/inferred_alleles.py
@@ -1,7 +1,11 @@
+import threading
+
+
 class InferredAllele:
     def __init__(self):
         self.inferred_seq = {}
         self.last_allele_index = {}
+        self.lock = threading.Lock()  # Create a lock object
 
     def get_inferred_allele(self, sequence: str, allele: str) -> str:
         """Infer allele from the sequence
@@ -12,9 +16,10 @@ class InferredAllele:
         Returns:
             str: inferred allele
         """
-        if sequence not in self.inferred_seq:
-            return self.set_inferred_allele(sequence, allele)
-        return self.inferred_seq[sequence]
+        with self.lock:  # Acquire the lock
+            if sequence not in self.inferred_seq:
+                return self.set_inferred_allele(sequence, allele)
+            return self.inferred_seq[sequence]
 
     def set_inferred_allele(self, sequence: str, allele: str) -> None:
         """Set the inferred allele for the sequence

--- a/taranis/utils.py
+++ b/taranis/utils.py
@@ -80,6 +80,26 @@ def get_seq_direction(allele_sequence):
     return "Error"
 
 
+def check_additional_programs_installed(software_list: list) -> None:
+    """Check if the input list of programs are installed in the system
+
+    Args:
+        software_list (list): list of programs to be checked
+    """
+    for program in software_list:
+        try:
+            _ = subprocess.run(
+                [program, "-h"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=True,
+            )
+        except Exception as e:
+            log.error("Program %s is not installed in the system. Error message: %s ", program, e)
+            stderr.print("[red] Program " + program + " is not installed in the system")
+            sys.exit(1)
+    return
+
 def create_annotation_files(
     fasta_file: str,
     annotation_dir: str,

--- a/taranis/utils.py
+++ b/taranis/utils.py
@@ -284,6 +284,35 @@ def prompt_text(msg):
     return source
 
 
+def prompt_user_if_folder_exists(folder: str) -> bool:
+    """Prompt the user to continue if the folder exists
+
+    Args:
+        folder (str): folder path
+
+    Returns:
+        bool: True if user wants to continue
+    """
+    if folder_exists(folder):
+        q_question = (
+            "Folder "
+            + folder
+            + " already exists. Files will be overwritten. Do you want to continue?"
+        )
+        if "no" in query_user_yes_no(q_question, "no"):
+            log.info("Aborting code by user request")
+            stderr.print("[red] Exiting code. ")
+            sys.exit(1)
+    else:
+        try:
+            os.makedirs(folder)
+        except OSError as e:
+            log.info("Unable to create folder at %s with error %s", folder, e)
+            stderr.print("[red] ERROR. Unable to create folder  " + folder)
+            sys.exit(1)
+
+    return True
+
 def query_user_yes_no(question, default):
     """Query the user to choose yes or no for the query question
 

--- a/taranis/utils.py
+++ b/taranis/utils.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import glob
+import gzip
 import io
 import logging
 import multiprocessing
@@ -383,6 +384,36 @@ def read_annotation_file(ann_file: str) -> dict:
             break
     return ann_data
 
+def read_compressed_file(file_name: str, separator: str = ",", index_key: int=None, mapping: list=[]) -> dict|str:
+    """Read the compressed file and return a dictionary using as key value
+    the mapping data if the index_key is an integer, else return the uncompressed
+    file
+
+    Args:
+        file_name (str): file to be uncompressed
+        separator (str, optional): split line according separator. Defaults to ",".
+        index_key (int, optional): index value . Defaults to None.
+        mapping (list, optional): defined the key value for dictionary. Defaults to [].
+
+    Returns:
+        dict|str: uncompresed information file
+    """    
+    out_data = {}
+    with gzip.open(file_name, "rb") as fh:
+        lines = fh.readlines()
+    if not index_key:
+        return lines[:-2]
+    for line in lines[1:]:
+        line = line.decode("utf-8")
+        s_line = line.split(separator)
+        # ignore empty lines
+        if len(s_line) == 1:
+            continue
+        key_data =s_line[index_key]
+        out_data[key_data] = {}
+        for item in mapping:
+            out_data[key_data][item[0]] = s_line[item[1]]
+    return out_data
 
 def read_fasta_file(fasta_file):
     return SeqIO.parse(fasta_file, "fasta")

--- a/taranis/utils.py
+++ b/taranis/utils.py
@@ -86,19 +86,24 @@ def check_additional_programs_installed(software_list: list) -> None:
     Args:
         software_list (list): list of programs to be checked
     """
-    for program in software_list:
+    for program, command in software_list:
         try:
             _ = subprocess.run(
-                [program, "-h"],
+                [program, command],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 check=True,
             )
         except Exception as e:
-            log.error("Program %s is not installed in the system. Error message: %s ", program, e)
+            log.error(
+                "Program %s is not installed in the system. Error message: %s ",
+                program,
+                e,
+            )
             stderr.print("[red] Program " + program + " is not installed in the system")
             sys.exit(1)
     return
+
 
 def create_annotation_files(
     fasta_file: str,

--- a/taranis/utils.py
+++ b/taranis/utils.py
@@ -63,6 +63,11 @@ POSIBLE_BAD_QUALITY = [
 
 
 def cpus_available() -> int:
+    """Get the number of cpus available in the system
+
+    Returns:
+        int: number of cpus
+    """
     return multiprocessing.cpu_count()
 
 
@@ -252,10 +257,13 @@ def file_exists(file_to_check):
     return False
 
 
+""" 
 def find_nearest_numpy_value(array, value):
     array = np.asarray(array)
     idx = (np.abs(array - value)).argmin()
     return array[idx]
+
+ """
 
 
 def folder_exists(folder_to_check):
@@ -270,6 +278,28 @@ def folder_exists(folder_to_check):
     if os.path.isdir(folder_to_check):
         return True
     return False
+
+
+def get_alignment_data(allele_sequence: str, ref_sequences: dict[str]) -> dict:
+    """Get the alignment data between the allele sequence and the reference alleles
+
+    Args:
+        allele_sequence (str): sequence to be compared
+        ref_sequences (dict): sequences of reference alleles
+
+    Returns:
+        dict: key: ref_sequence, value: alignment data
+    """
+    alignment_data = {}
+    for ref_allele, ref_sequence in ref_sequences.items():
+        alignment = ""
+        for idx, (a, b) in enumerate(zip(allele_sequence, ref_sequence)):
+            if a == b:
+                alignment += "|"
+            else:
+                alignment += " "
+        alignment_data[ref_allele] = [ref_sequence, alignment, allele_sequence]
+    return alignment_data
 
 
 def get_files_in_folder(folder: str, extension: str = None) -> list[str]:
@@ -332,7 +362,7 @@ def grep_execution(input_file: str, pattern: str, parameters: str) -> list[str]:
             text=True,
         )
     except subprocess.CalledProcessError as e:
-        log.error("Unable to run grep. Error message: %s ", e)
+        log.debug("Unable to run grep. Error message: %s ", e)
         return []
     return result.stdout.split("\n")
 

--- a/taranis/utils.py
+++ b/taranis/utils.py
@@ -372,9 +372,9 @@ def read_annotation_file(ann_file: str) -> dict:
 
     for line in lines:
         if "Prodigal" in line:
-            gene_match = re.search(r"(.*)[\t]Prodigal.*gene=(\w+)_.*", line)
+            gene_match = re.search(r"(.*)[\t]Prodigal.*gene=(\w+)_.*product=(.*)", line)
             if gene_match:
-                ann_data[gene_match.group(1)] = gene_match.group(2)
+                ann_data[gene_match.group(1)] = {"gene": gene_match.group(2) , "product": gene_match.group(3).strip()}
             else:
                 pred_match = re.search(r"(.*)[\t]Prodigal.*product=(\w+)_.*", line)
                 if pred_match:

--- a/taranis/utils.py
+++ b/taranis/utils.py
@@ -281,16 +281,36 @@ def get_files_in_folder(folder: str, extension: str = None) -> list[str]:
     return glob.glob(folder_files)
 
 
-def grep_execution(input_file: str, pattern: str, parameters: str) -> list:
-    """_summary_
+def get_snp_position(allele_sequence: str, ref_sequences: dict[str]) -> dict[list[str]]:
+    """Get the snp position between the allele sequence and the reference alleles
 
     Args:
-        input_file (str): _description_
-        pattern (str): _description_
-        parmeters (str): _description_
+        allele_sequence (str): sequence to be compared
+        ref_sequences (dict): sequences of reference alleles
 
     Returns:
-        list: _description_
+        dict: key: ref_sequence, value: list of snp position
+    """
+    snp_data = {}
+    for ref_allele, ref_sequence in ref_sequences.items():
+        snp_position = []
+        for idx, (a, b) in enumerate(zip(allele_sequence, ref_sequence)):
+            if a != b:
+                snp_position.append([str(idx), a, b])
+        snp_data[ref_allele] = snp_position
+    return snp_data
+
+
+def grep_execution(input_file: str, pattern: str, parameters: str) -> list[str]:
+    """run grep command and return the output
+
+    Args:
+        input_file (str): input file path
+        pattern (str): pattern to be searched
+        parmeters (str): parameters to be used in grep
+
+    Returns:
+        list[str]: list of lines which match the pattern
     """
     try:
         result = subprocess.run(

--- a/taranis/utils.py
+++ b/taranis/utils.py
@@ -313,6 +313,7 @@ def prompt_user_if_folder_exists(folder: str) -> bool:
 
     return True
 
+
 def query_user_yes_no(question, default):
     """Query the user to choose yes or no for the query question
 

--- a/taranis/utils.py
+++ b/taranis/utils.py
@@ -375,7 +375,10 @@ def read_annotation_file(ann_file: str) -> dict:
         if "Prodigal" in line:
             gene_match = re.search(r"(.*)[\t]Prodigal.*gene=(\w+)_.*product=(.*)", line)
             if gene_match:
-                ann_data[gene_match.group(1)] = {"gene": gene_match.group(2) , "product": gene_match.group(3).strip()}
+                ann_data[gene_match.group(1)] = {
+                    "gene": gene_match.group(2),
+                    "product": gene_match.group(3).strip(),
+                }
             else:
                 pred_match = re.search(r"(.*)[\t]Prodigal.*product=(\w+)_.*", line)
                 if pred_match:
@@ -384,7 +387,10 @@ def read_annotation_file(ann_file: str) -> dict:
             break
     return ann_data
 
-def read_compressed_file(file_name: str, separator: str = ",", index_key: int=None, mapping: list=[]) -> dict|str:
+
+def read_compressed_file(
+    file_name: str, separator: str = ",", index_key: int = None, mapping: list = []
+) -> dict | str:
     """Read the compressed file and return a dictionary using as key value
     the mapping data if the index_key is an integer, else return the uncompressed
     file
@@ -397,7 +403,7 @@ def read_compressed_file(file_name: str, separator: str = ",", index_key: int=No
 
     Returns:
         dict|str: uncompresed information file
-    """    
+    """
     out_data = {}
     with gzip.open(file_name, "rb") as fh:
         lines = fh.readlines()
@@ -409,11 +415,12 @@ def read_compressed_file(file_name: str, separator: str = ",", index_key: int=No
         # ignore empty lines
         if len(s_line) == 1:
             continue
-        key_data =s_line[index_key]
+        key_data = s_line[index_key]
         out_data[key_data] = {}
         for item in mapping:
             out_data[key_data][item[0]] = s_line[item[1]]
     return out_data
+
 
 def read_fasta_file(fasta_file):
     return SeqIO.parse(fasta_file, "fasta")

--- a/taranis/utils.py
+++ b/taranis/utils.py
@@ -24,7 +24,6 @@ from pathlib import Path
 from Bio import SeqIO
 from Bio.Seq import Seq
 from collections import OrderedDict
-import pdb
 
 import warnings
 from Bio import BiopythonWarning
@@ -430,10 +429,16 @@ def get_snp_information(
     warnings.simplefilter("ignore", BiopythonWarning)
     snp_info = {}
     ref_protein = str(Seq(ref_sequence).translate())
-    try:
-        alt_protein = str(Seq(alt_sequence).translate())
-    except:
-        pdb.set_trace()
+    if len(alt_sequence) % 3 != 0:
+        log.debug(
+            "Sequence %s is not a multiple of three. Removing last nucleotides",
+            ref_allele_name,
+        )
+        # remove the last nucleotides to be able to translate to protein
+        alt_sequence = alt_sequence[: len(alt_sequence) // 3 * 3]
+
+    alt_protein = str(Seq(alt_sequence).translate())
+
 
     snp_line = []
     # get the shortest sequence for the loop

--- a/taranis/utils.py
+++ b/taranis/utils.py
@@ -438,8 +438,6 @@ def get_snp_information(
         alt_sequence = alt_sequence[: len(alt_sequence) // 3 * 3]
 
     alt_protein = str(Seq(alt_sequence).translate())
-
-
     snp_line = []
     # get the shortest sequence for the loop
     length_for_snp = min(len(ref_sequence), len(alt_sequence))

--- a/taranis/utils.py
+++ b/taranis/utils.py
@@ -29,8 +29,6 @@ from collections import OrderedDict
 import warnings
 from Bio import BiopythonWarning
 
-import pdb
-
 log = logging.getLogger(__name__)
 
 
@@ -447,7 +445,13 @@ def get_snp_information(
             ref_aa = ref_protein[triplet_idx]
             try:
                 alt_aa = alt_protein[triplet_idx]
-            except:
+            except IndexError as e:
+                log.debug(
+                    "Unable to get amino acid for %s and %s with error %s",
+                    ref_allele_name,
+                    alt_sequence,
+                    e,
+                )
                 alt_aa = "-"
             # get amino acid category
             ref_category = map_amino_acid_to_annotation(ref_sequence[triplet_idx])

--- a/taranis/utils.py
+++ b/taranis/utils.py
@@ -377,18 +377,20 @@ def get_files_in_folder(folder: str, extension: str = None) -> list[str]:
     return glob.glob(folder_files)
 
 
-def get_multiple_alignment(input_buffer: io.StringIO) -> list[str]:
+def get_multiple_alignment(input_buffer: io.StringIO, mafft_cpus: int) -> list[str]:
     """Run MAFFT with input from the string buffer and capture output to another string buffer
 
     Args:
         input_buffer (io.StringIO): fasta sequences to be aligned
-
+        mafft_cpus (int): number of cpus to be used in mafft
     Returns:
         list[str]: list of aligned sequences
     """
     output_buffer = io.StringIO()
     # Run MAFFT
-    mafft_command = "mafft --auto --quiet -"  # "-" tells MAFFT to read from stdin
+    mafft_command = (
+        "mafft --auto --quiet --thread " + str(mafft_cpus) + " -"
+    )  # "-" tells MAFFT to read from stdin
     process = subprocess.Popen(
         mafft_command, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE
     )

--- a/taranis/utils.py
+++ b/taranis/utils.py
@@ -4,7 +4,6 @@ import gzip
 import io
 import logging
 import multiprocessing
-import numpy as np
 import os
 import pandas as pd
 import plotly.graph_objects as go
@@ -257,7 +256,7 @@ def file_exists(file_to_check):
     return False
 
 
-""" 
+"""
 def find_nearest_numpy_value(array, value):
     array = np.asarray(array)
     idx = (np.abs(array - value)).argmin()


### PR DESCRIPTION
Implementation of allele calling
In this PR, when it is searching the specif allele that  match the blast sequence using grep, if grep match then this specific allele name will be set as the field of coding. This is to find the EXC allele, but could be set in conditions of ASM or ALM or PLOT, where part of the sequence match in the locus file.

 -  [x] save all coordinates in case NIPHEM/NIPH
 -  [x] if no blast result are with 80% query. it is considered from 75% and assigned to PLOT
 -  [x] check if programs like mash, prokka, etc exist before start execution
    - [x] mash
    - [x] prokka
    - [x] blast 
 -  [x] create SNP file all alleles compared with their Reference allele. including 3 DNA bases for ref and alt, Amino acid for ref and  alt and change type of amino acid
 -  [x] Create multi alignment for each allele  with the reference allele
 -  [x] create summary graphic for all samples and all allele classification 
 -  [x] update code to process all samples
 -  [x]  ensure that the get_inferred_allele method is accessed safely by multiple instances
 -  [x] Extend blast sequence for searching start and stop codon due to the variability in reference alleles
-   [x] Parallel execution to create the multi alignment files

Important Note .-
This PR includes changes in analyze schema feature. This means it is mandatory to re-run the analyze schema to get the right annotation file