### PR TITLE
Fixes in allele calling module

### DIFF
--- a/taranis/__main__.py
+++ b/taranis/__main__.py
@@ -414,12 +414,12 @@ def reference_alleles(
 )
 @click.option(
     "-t",
-    "--threshold",
+    "--hit_lenght_perc",
     required=False,
     nargs=1,
     default=0.8,
     type=float,
-    help="Threshold value to consider in blast. Values from 0 to 1. default 0.8",
+    help="Threshold value to consider in blast hit percentage regarding the reference length. Values from 0 to 1. default 0.8",
 )
 @click.option(
     "-p",
@@ -494,7 +494,7 @@ def allele_calling(
     reference: str,
     annotation: str,
     assemblies: list,
-    threshold: float,
+    hit_lenght_perc: float,
     perc_identity: int,
     output: str,
     force: bool,
@@ -546,7 +546,7 @@ def allele_calling(
                 schema,
                 prediction_data,
                 schema_ref_files,
-                threshold,
+                hit_lenght_perc,
                 perc_identity,
                 output,
                 inf_allele_obj,

--- a/taranis/__main__.py
+++ b/taranis/__main__.py
@@ -278,7 +278,7 @@ def analyze_schema(
     "--eval-cluster/--no-eval-cluster",
     required=False,
     default=True,
-    help="Evaluate if the reference alleles match against blast with a 90% identity",
+    help="Evaluate if the reference alleles match against blast with the identity set in eval-identity param",
 )
 @click.option(
     "-k",
@@ -302,6 +302,14 @@ def analyze_schema(
     required=False,
     type=float,
     default=0.75,
+    help="Resolution value used for clustering.",
+)
+@click.option(
+    "-e",
+    "--eval-identity",
+    required=False,
+    type=float,
+    default=85,
     help="Resolution value used for clustering.",
 )
 @click.option(
@@ -332,6 +340,7 @@ def reference_alleles(
     kmer_size: int,
     sketch_size: int,
     cluster_resolution: float,
+    eval_identity: float,
     seed: int,
     cpus: int,
     force: bool,
@@ -362,6 +371,7 @@ def reference_alleles(
                 kmer_size,
                 sketch_size,
                 cluster_resolution,
+                eval_identity,
                 seed,
             )
             for f_file in schema_files

--- a/taranis/__main__.py
+++ b/taranis/__main__.py
@@ -517,7 +517,6 @@ def allele_calling(
     if not force:
         _ = taranis.utils.prompt_user_if_folder_exists(output)
     # Filter fasta files from reference folder
-    # ref_alleles = glob.glob(os.path.join(reference, "*.fasta"))
     max_cpus = taranis.utils.cpus_available()
     if cpus > max_cpus:
         stderr.print("[red] Number of CPUs bigger than the CPUs available")
@@ -563,32 +562,13 @@ def allele_calling(
             except Exception as e:
                 print(e)
                 continue
-    """
-    for assembly_file in assemblies:
-        results.append(
-            taranis.allele_calling.parallel_execution(
-                assembly_file,
-                schema,
-                prediction_data,
-                schema_ref_files,
-                threshold,
-                perc_identity,
-                output,
-                inf_allele_obj,
-                snp,
-                alignment,
-                proteine_threshold,
-                increase_sequence,
-            )
-        )
-    """
+
     _ = taranis.allele_calling.collect_data(
         results, output, snp, alignment, schema_ref_files, cpus
     )
     finish = time.perf_counter()
     print(f"Allele calling finish in {round((finish-start)/60, 2)} minutes")
     log.info("Allele calling finish in %s minutes", round((finish - start) / 60, 2))
-    # sample_allele_obj.analyze_sample()
 
 
 @taranis_cli.command(help_priority=3)

--- a/taranis/allele_calling.py
+++ b/taranis/allele_calling.py
@@ -328,16 +328,12 @@ class AlleleCalling:
             elif _check_if_plot(b_split_data):
                 # match allele is partial length labelled as PLOT
                 classification = "PLOT"
-            # check if protein length divided by the length of triplet matched
-            # sequence is lower the the tpr limit
+            # check if protein translation has failed and set to TPR
             elif (
-                b_split_data[14] == "Multiple stop codons"
-                and b_split_data[17].index("*") / (int(b_split_data[6]) / 3)
-                < self.tpr_limit
+                b_split_data[14] != "-"
             ):
-                # labelled as TPR
                 classification = "TPR"
-                # check if match allele is shorter than reference allele
+            # check if match allele is shorter than reference allele
             elif int(b_split_data[6]) < int(b_split_data[5]) - int(b_split_data[5]) * 0.20:
                 classification = "ASM"
             # check if match allele is longer than reference allele
@@ -351,7 +347,7 @@ class AlleleCalling:
             # assign an identification value to the new allele
             if match_allele_schema == "":
                 match_allele_schema = str(
-                    self.inf_alle_obj.get_inferred_allele(b_split_data[14], locus_name)
+                    self.inf_alle_obj.get_inferred_allele(b_split_data[15], locus_name)
                 )
             b_split_data[4] = classification + "_" + match_allele_schema
         return [

--- a/taranis/allele_calling.py
+++ b/taranis/allele_calling.py
@@ -258,7 +258,7 @@ class AlleleCalling:
             )
             return allele_details
 
-        def _classify_allele(allele_file: str, match_sequence: str) -> str:
+        def _classify_allele(locus_file: str, match_sequence: str) -> str:
             """Find the allele name in the schema that match the sequence
 
             Args:
@@ -271,7 +271,7 @@ class AlleleCalling:
             # Read the fasta file and create a dictionary mapping sequences to their record IDs
             sequence_dict = {
                 str(record.seq): record.id
-                for record in SeqIO.parse(allele_file, "fasta")
+                for record in SeqIO.parse(locus_file, "fasta")
             }
 
             # Check if the match_sequence is in the dictionary and return the corresponding record ID part
@@ -417,6 +417,7 @@ class AlleleCalling:
             match_allele_schema = _classify_allele(
                 locus_file, sample_allele_data["sample_allele_seq"]
             )
+
             # PLOT, TPR, ASM, ALM, INF, EXC are possible classifications
             if match_allele_schema:
                 # exact match found labelled as EXC

--- a/taranis/allele_calling.py
+++ b/taranis/allele_calling.py
@@ -277,12 +277,14 @@ class AlleleCalling:
             Returns:
                 str: allele name in the schema that match the sequence
             """
-            grep_result = taranis.utils.grep_execution(
-                allele_file, match_sequence, "-xb1"
-            )
-            if len(grep_result) > 0:
-                return grep_result[0].split("_")[1]
-            return ""
+            # Read the fasta file and create a dictionary mapping sequences to their record IDs
+            sequence_dict = {str(record.seq): record.id for record in SeqIO.parse(allele_file, "fasta")}
+
+            # Check if the match_sequence is in the dictionary and return the corresponding record ID part
+            if match_sequence in sequence_dict:
+                return sequence_dict[match_sequence]
+
+            return ""  # Return an empty string if no match is found
 
         # valid_blast_results = _discard_low_threshold_results(blast_results)
         match_allele_schema = ""
@@ -336,12 +338,11 @@ class AlleleCalling:
                 # labelled as TPR
                 classification = "TPR"
                 # check if match allele is shorter than reference allele
-            elif int(b_split_data[6]) < int(b_split_data[5]):
+            elif int(b_split_data[6]) < int(b_split_data[5]) - int(b_split_data[5]) * 0.20:
                 classification = "ASM"
             # check if match allele is longer than reference allele
             elif (
-                int(b_split_data[6]) > int(b_split_data[5])
-                or b_split_data[14] == "Last sequence is not a stop codon"
+                int(b_split_data[6]) > int(b_split_data[5]) + int(b_split_data[5]) * 0.20
             ):
                 classification = "ALM"
             else:

--- a/taranis/allele_calling.py
+++ b/taranis/allele_calling.py
@@ -667,7 +667,11 @@ def parallel_execution(
 
 
 def create_multiple_alignment(
-    ref_alleles_seq: dict, results: list, locus: str, alignment_folder: str, mafft_cpus: int
+    ref_alleles_seq: dict,
+    results: list,
+    locus: str,
+    alignment_folder: str,
+    mafft_cpus: int,
 ) -> None:
     """Create multiple alignmet file for each locus
 
@@ -701,7 +705,9 @@ def create_multiple_alignment(
                     + "\n"
                 )
                 # get the sequence of the allele in sample
-                input_buffer.write(values["allele_details"][locus]["sample_allele_seq"] + "\n")
+                input_buffer.write(
+                    values["allele_details"][locus]["sample_allele_seq"] + "\n"
+                )
         input_buffer.seek(0)
 
         allele_multiple_align.append(

--- a/taranis/allele_calling.py
+++ b/taranis/allele_calling.py
@@ -215,7 +215,6 @@ class AlleleCalling:
             direction, protein, prot_error, prot_error_details = (
                 taranis.utils.convert_to_protein(match_sequence, force_coding=True)
             )
-            import pdb; pdb.set_trace()
             start = split_blast_result[9]
             end = split_blast_result[10]
             if prot_error:
@@ -245,7 +244,6 @@ class AlleleCalling:
                     )
                     start = new_start
                     end = new_end
-
             # get blast details
             blast_details = [
                 self.s_name,  # sample name
@@ -291,11 +289,12 @@ class AlleleCalling:
         # if len(valid_blast_results) == 0:
         # no match results labelled as LNF. details data filled with empty data
         #    return ["LNF", "LNF", ["-"] * 18]
-        import pdb; pdb.set_trace()
+
         if len(valid_blast_results) > 1:
             # could  be NIPHEM or NIPH
             b_split_data = []
             match_allele_seq = []
+
             for valid_blast_result in valid_blast_results:
                 multi_allele_data = _get_blast_details(
                     valid_blast_result, locus_name, ref_allele_seq
@@ -303,21 +302,12 @@ class AlleleCalling:
                 # get match allele sequence
                 match_allele_seq.append(multi_allele_data[14])
                 b_split_data.append(multi_allele_data)
-                # check if match allele is in schema
-                if match_allele_schema == "":
-                    # find the allele in schema with the match sequence in the contig
-                    match_allele_schema = _find_match_allele_schema(
-                        locus_file, multi_allele_data[15]
-                    )
             if len(set(match_allele_seq)) == 1:
                 # all sequuences are equal labelled as NIPHEM
                 classification = "NIPHEM"
             else:
                 # some of the sequences are different labelled as NIPH
                 classification = "NIPH"
-            # update coding allele type
-            for (idx,) in range(len(b_split_data)):
-                b_split_data[idx][4] = classification + "_" + match_allele_schema
         else:
             b_split_data = _get_blast_details(
                 valid_blast_results[0], locus_name, ref_allele_seq
@@ -326,7 +316,6 @@ class AlleleCalling:
             match_allele_schema = _find_match_allele_schema(
                 locus_file, b_split_data[15]
             )
-
             # PLOT, TPR, ASM, ALM, INF, EXC are possible classifications
             if match_allele_schema != "":
                 # exact match found labelled as EXC
@@ -355,7 +344,6 @@ class AlleleCalling:
             else:
                 # if sequence was not found after running grep labelled as INF
                 classification = "INF"
-
             # assign an identification value to the new allele
             if match_allele_schema == "":
                 match_allele_schema = str(
@@ -413,12 +401,7 @@ class AlleleCalling:
         for ref_allele in self.ref_alleles:
             count += 1
             log.debug(
-                " Processing allele ",
-                ref_allele,
-                " ",
-                count,
-                " of ",
-                len(self.ref_alleles),
+                f"Processing allele {ref_allele}: {count} of {len(self.ref_alleles)}"
             )
 
             alleles = taranis.utils.read_fasta_file(ref_allele, convert_to_dict=True)
@@ -427,7 +410,7 @@ class AlleleCalling:
             for r_id, r_seq in alleles.items():
                 count_2 += 1
 
-                log.debug("Running blast for ", count_2, " of ", len(alleles))
+                log.debug(f"Running blast for {count_2} of  {len(alleles)}")
                 # create file in memory to increase speed
                 query_file = io.StringIO()
                 query_file.write(">" + r_id + "\n" + r_seq)
@@ -447,7 +430,6 @@ class AlleleCalling:
                         break
                 # Close object and discard memory buffer
                 query_file.close()
-
             locus_file = os.path.join(self.schema, os.path.basename(ref_allele))
             locus_name = Path(locus_file).stem
 

--- a/taranis/allele_calling.py
+++ b/taranis/allele_calling.py
@@ -371,6 +371,18 @@ class AlleleCalling:
                         sample_allele_data["prot_error"] = prot_error
                         sample_allele_data["prot_error_details"] = prot_error_details
 
+            match_allele_schema = _classify_allele(
+                locus_file, sample_allele_data["sample_allele_seq"]
+            )
+            if match_allele_schema:
+                # exact match found labelled as EXC
+                classification = "EXC"
+                sample_allele_data["allele_type"] = classification + "_" + match_allele_schema
+                return [
+                    classification,
+                    classification + "_" + match_allele_schema,
+                    sample_allele_data,
+                ]
             if sample_allele_data["prot_error"]:
                 classification = "TPR"
             # check if match allele is shorter than reference allele
@@ -714,7 +726,7 @@ def collect_data(
     allele_matrix_result = {}  # used for allele match file
 
     # get allele list
-    locus_list = [Path(ref_allele).stem for ref_allele in ref_alleles]
+    locus_list = [Path(ref_allele).stem for ref_allele in ref_alleles].sort()
 
     for result in results:
         for sample, values in result.items():

--- a/taranis/allele_calling.py
+++ b/taranis/allele_calling.py
@@ -353,7 +353,7 @@ class AlleleCalling:
                         sample_allele_data["prot_error_details"] = prot_error_details
 
                 elif "is not a start codon" in sample_allele_data["prot_error_details"]:
-                    protein, new_start, new_end, prot_error, prot_error_details = (
+                    protein, extended_seq, new_start, new_end, prot_error, prot_error_details = (
                         _extend_seq_find_start_stop_codon(
                             direction=direction_contig,
                             contig_seq=self.sample_contigs[sample_allele_data["contig_name"]],

--- a/taranis/clustering.py
+++ b/taranis/clustering.py
@@ -42,8 +42,7 @@ class ClusterDistance:
     def calculate_cluster_center(
         self, cluster_mtrx_idxs: tuple, dist_value: float
     ) -> int:
-        """Get the center allele for the cluster by selecting the allele closest
-            value to cluster mean
+        """Get the center allele for the cluster by selecting the allele with more alleles at > dist_value
 
         Args:
             cluster_mtrx_idxs (tuple): tuple with the filter indexes to create

--- a/taranis/eval_cluster.py
+++ b/taranis/eval_cluster.py
@@ -17,7 +17,7 @@ stderr = rich.console.Console(
 
 
 class EvaluateCluster:
-    def __init__(self, locus_path: str, locus_name: str, output: str):
+    def __init__(self, locus_path: str, locus_name: str, eval_id: float, output: str):
         """EvaluateCluster instance creation
 
         Args:
@@ -27,6 +27,7 @@ class EvaluateCluster:
         """
         self.locus_path = locus_path
         self.locus_name = locus_name
+        self.eval_id = eval_id
 
         self.output = os.path.join(output, "evaluate_cluster")
         taranis.utils.create_new_folder(self.output)
@@ -156,7 +157,7 @@ class EvaluateCluster:
             query_file.write(">" + r_id + "\n" + r_seq)
             query_file.seek(0)
             blast_result = self.blast_obj.run_blast(
-                query_file.read(), perc_identity=85, query_type="stdin"
+                query_file.read(), perc_identity=self.eval_id, query_type="stdin"
             )
             # Close object and discard memory buffer
             query_file.close()

--- a/taranis/reference_alleles.py
+++ b/taranis/reference_alleles.py
@@ -160,7 +160,7 @@ class ReferenceAlleles:
             # evaluate clusters aginst blast results
             stderr.print(f"Evaluating clusters for {self.locus_name}")
             evaluation_obj = taranis.eval_cluster.EvaluateCluster(
-                self.fasta_file, self.locus_name, self.output
+                self.fasta_file, self.locus_name, self.eval_id, self.output
             )
             evaluation_result = evaluation_obj.evaluate_clusters(
                 allele_data["alleles_in_cluster"],

--- a/taranis/reference_alleles.py
+++ b/taranis/reference_alleles.py
@@ -28,6 +28,7 @@ class ReferenceAlleles:
         kmer_size: int,
         sketch_size: int,
         cluster_resolution: float = 0.75,
+        eval_id: float = 85,
         seed: int = None,
     ):
         """ReferenceAlleles instance creation
@@ -48,6 +49,7 @@ class ReferenceAlleles:
         self.kmer_size = kmer_size
         self.sketch_size = sketch_size
         self.cluster_resolution = cluster_resolution
+        self.eval_id = eval_id
         self.seed = seed
         self.selected_locus = {}
         self.cluster_obj = None
@@ -138,8 +140,9 @@ class ReferenceAlleles:
         self.records = taranis.utils.read_fasta_file(self.fasta_file)
         dist_matrix_np, position_to_allele = self.create_distance_matrix()
         self.cluster_obj = taranis.clustering.ClusterDistance(
-            dist_matrix_np,
-            self.locus_name,
+            dist_matrix=dist_matrix_np,
+            ref_seq_name=self.locus_name,
+            dist_value=self.eval_id / 100,
         )
 
         for resolution in np.arange(self.cluster_resolution, 1, 0.025):

--- a/taranis/reference_alleles.py
+++ b/taranis/reference_alleles.py
@@ -193,6 +193,7 @@ def parallel_execution(
     kmer_size: int,
     sketch_size: int,
     cluster_resolution: float,
+    eval_identity: float,
     seed: int,
 ):
     """Parallel execution of the reference alleles creation
@@ -213,6 +214,7 @@ def parallel_execution(
         kmer_size,
         sketch_size,
         cluster_resolution,
+        eval_identity,
         seed,
     )
     return ref_alleles_obj.create_ref_alleles()

--- a/taranis/reference_alleles.py
+++ b/taranis/reference_alleles.py
@@ -246,12 +246,12 @@ def collect_statistics(data_alleles: list, eval_cluster: bool, out_folder: str) 
         cluster, alleles = zip(*cluster_alleles.items())
         _ = taranis.utils.create_graphic(
             graphic_folder,
-            "num_genes_per_allele.png",
+            "num_clusters_per_locus.png",
             "bar",
             cluster,
             alleles,
-            ["Gene", "Number of clusters"],
-            "Number of cluster per gene",
+            ["# clusters", " #locus"],
+            "Clusters per locus",
         )
 
     # split into cluster_data and evaluation_data

--- a/taranis/utils.py
+++ b/taranis/utils.py
@@ -70,10 +70,20 @@ POSIBLE_BAD_QUALITY = [
 
 
 def has_start_codon(seq):
+    """ Checks whether the sequence has a start codon
+
+    Returns:
+        bool
+    """
     return seq[:3] in START_CODON_FORWARD or seq[-3:] in START_CODON_REVERSE
 
 
 def has_stop_codon(seq):
+    """ Checks whether the sequence has a stop codon
+
+    Returns:
+        bool
+    """
     return seq[:3] in STOP_CODON_FORWARD or seq[-3:] in STOP_CODON_REVERSE
 
 
@@ -87,7 +97,13 @@ def cpus_available() -> int:
 
 
 def get_seq_direction(allele_sequence):
-    # check direction
+    """ Get sequence direction
+
+    Returns:
+        "forward" if found a start or stop codon in forward
+        "reverse" if found start or stop codon in reverse
+        "both" if none of those are found, could be either strands
+    """
     if (
         allele_sequence[0:3] in START_CODON_FORWARD
         or allele_sequence[-3:] in STOP_CODON_FORWARD

--- a/taranis/utils.py
+++ b/taranis/utils.py
@@ -130,7 +130,9 @@ def convert_to_protein(
 
     Returns:
         direction(str): reverse or forward
-        protein (str): 1protein sequence and/or error message
+        protein (str): protein sequence
+        error (bool): True/False
+        error_detail (str): translate method error
     """
     protein = "-"
     error = False
@@ -500,30 +502,6 @@ def get_snp_information(
             )
     snp_info[ref_allele_name] = snp_line
     return snp_info
-
-
-def grep_execution(input_file: str, pattern: str, parameters: str) -> list[str]:
-    """run grep command and return the output
-
-    Args:
-        input_file (str): input file path
-        pattern (str): pattern to be searched
-        parmeters (str): parameters to be used in grep
-
-    Returns:
-        list[str]: list of lines which match the pattern
-    """
-    try:
-        result = subprocess.run(
-            ["grep", parameters, pattern, input_file],
-            capture_output=True,
-            check=True,
-            text=True,
-        )
-    except subprocess.CalledProcessError as e:
-        log.debug("Unable to run grep. Error message: %s ", e)
-        return []
-    return result.stdout.split("\n")
 
 
 def map_amino_acid_to_annotation(amino_acid):

--- a/taranis/utils.py
+++ b/taranis/utils.py
@@ -118,9 +118,7 @@ def check_additional_programs_installed(software_list: list) -> None:
     return
 
 
-def convert_to_protein(
-    sequence: str, force_coding: bool = False
-) -> dict:
+def convert_to_protein(sequence: str, force_coding: bool = False) -> dict:
     """Check if the input sequence is a coding protein.
 
     Args:
@@ -147,8 +145,9 @@ def convert_to_protein(
     try:
         # Table 11 is for bacteria, archaea and chloroplast
         protein = seq.translate(table=11, to_stop=False, cds=force_coding)
-    except Bio.Data.CodonTable.TranslationError as error_detail:
+    except Bio.Data.CodonTable.TranslationError as e:
         error = True
+        error_detail = str(e)
         log.debug(f"Error when translating protein {error_detail}")
 
     return direction, str(protein), error, error_detail

--- a/taranis/utils.py
+++ b/taranis/utils.py
@@ -70,7 +70,7 @@ POSIBLE_BAD_QUALITY = [
 
 
 def has_start_codon(seq):
-    """ Checks whether the sequence has a start codon
+    """Checks whether the sequence has a start codon
 
     Returns:
         bool
@@ -79,7 +79,7 @@ def has_start_codon(seq):
 
 
 def has_stop_codon(seq):
-    """ Checks whether the sequence has a stop codon
+    """Checks whether the sequence has a stop codon
 
     Returns:
         bool
@@ -97,7 +97,7 @@ def cpus_available() -> int:
 
 
 def get_seq_direction(allele_sequence):
-    """ Get sequence direction
+    """Get sequence direction
 
     Returns:
         "forward" if found a start or stop codon in forward

--- a/taranis/utils.py
+++ b/taranis/utils.py
@@ -69,6 +69,14 @@ POSIBLE_BAD_QUALITY = [
 ]
 
 
+def has_start_codon(seq):
+    return seq[:3] in START_CODON_FORWARD or seq[-3:] in START_CODON_REVERSE
+
+
+def has_stop_codon(seq):
+    return seq[:3] in STOP_CODON_FORWARD or seq[-3:] in STOP_CODON_REVERSE
+
+
 def cpus_available() -> int:
     """Get the number of cpus available in the system
 


### PR DESCRIPTION
- Added evaluation identity as parameter for reference alleles
- Variable and function renaming as refactor for allele_calling module
- changed exact match detection from grep to biopython
- Fix when allele was LNF was classified as locus_name instead of LNF
- Changed allele_details format from list to dictionary for easier reading and use.
- ASM and ALM evaluation is when sample allele seq is greater or lesser than the reference allele length +/- 20% of its length
- Refactor protein fixed when sample allele seq can't be translated:
    - Now is executed after checking for exact match 
    - Now checks for both forward and reverse senses, as well as, contig strand.
    - Tries to extend in case of not stop codon, not start codon and not multiple of three.
    - Now it directly uses biopython translate errors.